### PR TITLE
Added weighted Falkon features

### DIFF
--- a/doc/api_reference/optimization.rst
+++ b/doc/api_reference/optimization.rst
@@ -25,3 +25,9 @@ FalkonConjugateGradient
 
 .. autoclass:: FalkonConjugateGradient
     :members:
+
+WFalkonConjugateGradient
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: WFalkonConjugateGradient
+    :members:

--- a/falkon/models/incore_falkon.py
+++ b/falkon/models/incore_falkon.py
@@ -67,6 +67,9 @@ class InCoreFalkon(FalkonBase):
         `error_every` iterations. If set to 1 then the error will be
         calculated at each iteration. If set to None, it will never be
         calculated.
+    weight_fun : Callable or None
+        A function with one argument (a torch.Tensor containing the targets (or a subset of it)) which returns a vector of weights.
+        If set to None, it will never be used.
     options : FalkonOptions
         Additional options used by the components of the Falkon solver. Individual options
         are documented in :mod:`falkon.options`.
@@ -102,11 +105,13 @@ class InCoreFalkon(FalkonBase):
                  seed: Optional[int] = None,
                  error_fn: Optional[Callable[[torch.Tensor, torch.Tensor], float]] = None,
                  error_every: Optional[int] = 1,
+                 weight_fun = None,
                  options: Optional[FalkonOptions] = None,
                  ):
         super().__init__(kernel, M, center_selection, seed, error_fn, error_every, options)
         self.penalty = penalty
         self.maxiter = maxiter
+        self.weight_fun = weight_fun
         if not self.use_cuda_:
             raise RuntimeError("Cannot instantiate InCoreFalkon when CUDA is not available. "
                                "If CUDA is present on your system, make sure to set "
@@ -173,10 +178,20 @@ class InCoreFalkon(FalkonBase):
 
         t_s = time.time()
         # noinspection PyTypeChecker
-        ny_points: Union[torch.Tensor, falkon.sparse.SparseTensor] = self.center_selection.select(X, None, self.M)
-
+        if self.weight_fun is None:
+            ny_points: Union[torch.Tensor, falkon.sparse.SparseTensor] = self.center_selection.select(X, None, self.M)
+        else:
+            ny_points, ny_indices = self.center_selection.select(X, None, self.M)
         with TicToc("Calcuating Preconditioner of size %d" % (self.M), debug=self.options.debug):
-            precond = falkon.preconditioner.FalkonPreconditioner(self.penalty, self.kernel, self.options)
+
+
+            if self.weight_fun is None:
+                precond = falkon.preconditioner.FalkonPreconditioner(self.penalty, self.kernel, self.options, None)
+            else:
+                ny_weight_vec = self.weight_fun(Y[ny_indices])
+                precond = falkon.preconditioner.FalkonPreconditioner(self.penalty, self.kernel, self.options, ny_weight_vec)
+
+#            precond = falkon.preconditioner.FalkonPreconditioner(self.penalty, self.kernel, self.options)
             precond.init(ny_points)
 
         # Cache must be emptied to ensure enough memory is visible to the optimizer
@@ -200,7 +215,15 @@ class InCoreFalkon(FalkonBase):
 
         # Start with the falkon algorithm
         with TicToc('Computing Falkon iterations', debug=self.options.debug):
-            optim = falkon.optim.FalkonConjugateGradient(self.kernel, precond, self.options)
+
+
+#            optim = falkon.optim.FalkonConjugateGradient(self.kernel, precond, self.options)
+
+            if self.weight_fun is None:
+                optim = falkon.optim.FalkonConjugateGradient(self.kernel, precond, self.options)
+            else:
+                optim = falkon.optim.WFalkonConjugateGradient(self.kernel, precond, self.options, self.weight_fun)
+
             if Knm is not None:
                 beta = optim.solve(
                     Knm, None, Y, self.penalty, initial_solution=None,

--- a/falkon/optim/__init__.py
+++ b/falkon/optim/__init__.py
@@ -1,4 +1,4 @@
-from .conjgrad import Optimizer, ConjugateGradient, FalkonConjugateGradient
+from .conjgrad import Optimizer, ConjugateGradient, FalkonConjugateGradient, WFalkonConjugateGradient
 
-__all__ = ('Optimizer', 'ConjugateGradient', 'FalkonConjugateGradient')
+__all__ = ('Optimizer', 'ConjugateGradient', 'FalkonConjugateGradient', 'WFalkonConjugateGradient')
 

--- a/falkon/preconditioner/flk_preconditioner.py
+++ b/falkon/preconditioner/flk_preconditioner.py
@@ -109,6 +109,7 @@ class FalkonPreconditioner(Preconditioner):
 
         if self.weight_vec is not None:
             with TicToc("Add weight to lower triangular", debug = self.params.debug):
+                self.weight_vec.sqrt_()
                 vec_mul_triang(C, self.weight_vec.numpy().reshape(-1), side=0, upper=False)
 
         if self._use_cuda:


### PR DESCRIPTION
Added weight_fun parameter to Falkon (InCore Falkon) model (a function which takes the targets set (or a subset of it) and returns the vector of weights associated to the targets). 
Added WFalkonConjugateGradient which performs CG iterations for weighted Falkon. 
Changed center_selection.py, now it can returns also the indices of selected centers (used to build the weight vector for the preconditioner).
Added weight_vec parameter to FalkonPreconditioner: if this parameter is not None, the preconditioner will be weighted using this parameter.